### PR TITLE
Allow a simple string to specify the path for a namespace specification.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.1.16 - UNRELEASED
 
+* Namespace paths can now be a simple string as an alternative to a vector. E.g. `(rook/namespace-handler ["users" 'org.example.resources.users])`.
+
 ## 0.1.15 - 3 Oct 2014
 
 * The `new` and `edit` convention names for resource handler functions were removed.

--- a/spec/rook/rook_spec.clj
+++ b/spec/rook/rook_spec.clj
@@ -92,7 +92,8 @@
       (with handler (wrap-with-standard-middleware
                       (namespace-handler
                         [[] 'creator]
-                        [["nested"] 'creator])))
+                        [["nested"] 'creator]
+                        ["nested2" 'creator])))
       (with request {:scheme         :http
                      :server-name    "rook.aviso.io"
                      :server-port    80
@@ -114,6 +115,14 @@
                          h
                          (get-in [:headers "Location"])))))
 
+      (it "resolves the correct value for a nested resource when specified as a string"
+          (let [h @handler]
+            (should= "http://rook.aviso.io/nested2/<ID>"
+                     (-> @request
+                         (assoc :uri "/nested2")
+                         h
+                         (get-in [:headers "Location"])))))
+      
       (it "will use the :server-uri key if present"
           (should= "http://overrride.com/api/"
                    (internals/resource-uri-for {:server-uri "http://overrride.com"

--- a/src/io/aviso/rook/dispatcher.clj
+++ b/src/io/aviso/rook/dispatcher.clj
@@ -671,11 +671,13 @@
             (t/track
               #(format "Parsing namespace specification `%s'." (pr-str ns-spec))
               (consume ns-spec
-                [context-pathvec? #(or (nil? %) (vector? %)) :?
+                [context-pathvec? #(or (nil? %) (vector? %) (string? %)) :?
                  ns-sym symbol? 1
                  middleware fn? :?
                  nested :&]
-                (let [context-pathvec (or context-pathvec? [])]
+                (let [context-pathvec (if (string? context-pathvec?)
+                                          (vector context-pathvec?)
+                                          (or context-pathvec? []))]
                   (concat
                     [[(into outer-context-pathvec context-pathvec)
                       ns-sym


### PR DESCRIPTION
See #18.

The test here is fairly far removed from the code change, but it's at the level that gives me confidence it's working.
