### PR TITLE
Correct timeout behavior

### DIFF
--- a/src/io/aviso/rook/jetty_async_adapter.clj
+++ b/src/io/aviso/rook/jetty_async_adapter.clj
@@ -6,7 +6,7 @@
            (org.eclipse.jetty.continuation ContinuationSupport Continuation))
   (:require
     [clojure.tools.logging :as l]
-    [clojure.core.async :refer [go <! timeout alts! take! close!]]
+    [clojure.core.async :refer [go timeout alt! close!]]
     [io.aviso.rook.utils :as utils]
     [io.aviso.toolchest.collections :refer [pretty-print pretty-print-brief]]
     [ring.util


### PR DESCRIPTION
Bit of an interesting race condition here. Previously, when we completed
a response, we would also close the timeout channel. Because of how
timeouts are implemented, it is possible for one timeout to be shared
across multiple 'timeout' calls. As a result, if two requests came in
very close together, one could force an early timeout in the other, by
closing its timeout channel.

I've corrected this behavior by removing the erroneous close.
Separately, I also changed from two parallel takes, to a single go +
alt!.
