### PR TITLE
Link directly to documentation.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -16,4 +16,4 @@ without blocking all your threads.
 
 Rook is available under the terms of the Apache Software License 2.0.
 
-link:https://portal.aviso.io/#/docs/open-source[Full Documentation]
+link:https://portal.aviso.io/#/document/open-source/rook/Current[Full Documentation]


### PR DESCRIPTION
@hlship 

This takes people directly to the documentation which I think is preferable.