### PR TITLE
Add swagger tags

### DIFF
--- a/src/io/aviso/rook/swagger.clj
+++ b/src/io/aviso/rook/swagger.clj
@@ -355,6 +355,7 @@
         description  (or (:description swagger-meta)
                          (:doc endpoint-meta))
         summary      (:summary swagger-meta)
+        tags         (:tags swagger-meta)
         {:keys [path-params-injector query-params-injector body-params-injector responses-injector
                 operation-decorator]} swagger-options
         params-key   (concat paths-key ["parameters"])]
@@ -362,6 +363,7 @@
           (assoc-in % paths-key
                     (remove-nil-vals {:description description
                                       :summary     summary
+                                      :tags        tags
                                       ;; This is required inside a Operation object:
                                       :responses   (sorted-map)
                                       ;; There are a couple of scnearious where the function name is not


### PR DESCRIPTION
This allows easy grouping of endpoints.

`:tags` entry should be a string vector.