### PR TITLE
Updated dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,13 @@
             :url "https://github.com/AvisoNovate/rook"
             :license {:name "Apache Sofware License 2.0"
                       :url  "http://www.apache.org/licenses/LICENSE-2.0.html"}
+            ;; We only ever want to have the version of clojure we explicitly specify in the dependencies
+            :exclusions [org.clojure/clojure]
             :profiles {:dev
                        {:dependencies [[ring-mock "0.1.5"]
-                                       [cc.qbits/jet "0.6.6" :exclusions [org.clojure/clojure]]
-                                       [speclj "3.2.0" :exclusions [org.clojure/clojure]]
-                                       [io.aviso/logging "0.1.0" :exclusions [org.clojure/clojure]]
+                                       [cc.qbits/jet "0.6.6"]
+                                       [speclj "3.2.0"]
+                                       [io.aviso/logging "0.1.0"]
                                        [clj-http "2.0.0"]]}}
             ;; List "resolved" dependencies first, which occur when there are conflicts.
             ;; We pin down the version we want, then exclude anyone who disagrees.
@@ -21,12 +23,12 @@
                            [org.clojure/tools.reader "0.9.2"]
                            [org.clojure/tools.logging "0.3.1"]
                            [io.aviso/tracker "0.1.7"]
-                           [medley "0.6.0" :exclusions [com.keminglabs/cljx org.clojure/clojure]]
+                           [medley "0.6.0" :exclusions [com.keminglabs/cljx]]
                            [ring-middleware-format "0.6.0" :exclusions [ring/ring-devel org.clojure/tools.reader ring]]
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
                            [prismatic/schema "0.4.4"]]
             :plugins [[lein-ancient "0.6.7"]
-                      [speclj "3.2.0" :exclusions [org.clojure/clojure]]
+                      [speclj "3.2.0"]
                       [lein-shell "0.4.0"]]
             :jvm-opts ["-Xmx1g"]
             :shell {:commands {"scp" {:dir "doc"}}}

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :profiles {:dev
                        {:dependencies [[ring-mock "0.1.5"]
                                        [cc.qbits/jet "0.6.6"]
-                                       [speclj "3.2.0"]
+                                       [speclj "3.3.1"]
                                        [io.aviso/logging "0.1.0"]
                                        [clj-http "2.0.0"]]}}
             ;; List "resolved" dependencies first, which occur when there are conflicts.
@@ -28,7 +28,7 @@
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
                            [prismatic/schema "0.4.4"]]
             :plugins [[lein-ancient "0.6.7"]
-                      [speclj "3.2.0"]
+                      [speclj "3.3.1"]
                       [lein-shell "0.4.0"]]
             :jvm-opts ["-Xmx1g"]
             :shell {:commands {"scp" {:dir "doc"}}}

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,8 @@
                            [ring-middleware-format "0.5.0" :exclusions [ring/ring-devel org.clojure/tools.reader ring]]
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
                            [prismatic/schema "0.4.4"]]
-            :plugins [[speclj "3.2.0" :exclusions [org.clojure/clojure]]
+            :plugins [[lein-ancient "0.6.7"]
+                      [speclj "3.2.0" :exclusions [org.clojure/clojure]]
                       [lein-shell "0.4.0"]]
             :jvm-opts ["-Xmx1g"]
             :shell {:commands {"scp" {:dir "doc"}}}

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                                        [clj-http "2.0.0"]]}}
             ;; List "resolved" dependencies first, which occur when there are conflicts.
             ;; We pin down the version we want, then exclude anyone who disagrees.
-            :dependencies [[org.clojure/clojure "1.6.0"]
+            :dependencies [[org.clojure/clojure "1.7.0"]
                            [io.aviso/pretty "0.1.19"]
                            [io.aviso/toolchest "0.1.2"]
                            [cheshire "5.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                            [org.clojure/tools.logging "0.3.1"]
                            [io.aviso/tracker "0.1.7"]
                            [medley "0.7.0"]
-                           [ring-middleware-format "0.6.0" :exclusions [ring/ring-devel org.clojure/tools.reader ring]]
+                           [ring-middleware-format "0.6.0" :exclusions [org.clojure/tools.reader ring]]
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
                            [prismatic/schema "0.4.4"]]
             :plugins [[lein-ancient "0.6.7"]

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                            [org.clojure/tools.reader "0.9.2"]
                            [org.clojure/tools.logging "0.3.1"]
                            [io.aviso/tracker "0.1.7"]
-                           [medley "0.7.0" :exclusions [com.keminglabs/cljx]]
+                           [medley "0.7.0"]
                            [ring-middleware-format "0.6.0" :exclusions [ring/ring-devel org.clojure/tools.reader ring]]
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
                            [prismatic/schema "0.4.4"]]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                            [org.clojure/tools.logging "0.3.1"]
                            [io.aviso/tracker "0.1.7"]
                            [medley "0.6.0" :exclusions [com.keminglabs/cljx org.clojure/clojure]]
-                           [ring-middleware-format "0.5.0" :exclusions [ring/ring-devel org.clojure/tools.reader ring]]
+                           [ring-middleware-format "0.6.0" :exclusions [ring/ring-devel org.clojure/tools.reader ring]]
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
                            [prismatic/schema "0.4.4"]]
             :plugins [[lein-ancient "0.6.7"]

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                            [org.clojure/tools.reader "0.9.2"]
                            [org.clojure/tools.logging "0.3.1"]
                            [io.aviso/tracker "0.1.7"]
-                           [medley "0.6.0" :exclusions [com.keminglabs/cljx]]
+                           [medley "0.7.0" :exclusions [com.keminglabs/cljx]]
                            [ring-middleware-format "0.6.0" :exclusions [ring/ring-devel org.clojure/tools.reader ring]]
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
                            [prismatic/schema "0.4.4"]]

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                            [medley "0.7.0"]
                            [ring-middleware-format "0.6.0" :exclusions [org.clojure/tools.reader ring]]
                            [ring/ring-core "1.4.0" :exclusions [commons-fileupload]]
-                           [prismatic/schema "0.4.4"]]
+                           [prismatic/schema "1.0.1"]]
             :plugins [[lein-ancient "0.6.7"]
                       [speclj "3.3.1"]
                       [lein-shell "0.4.0"]]

--- a/src/io/aviso/rook/schema.clj
+++ b/src/io/aviso/rook/schema.clj
@@ -2,10 +2,9 @@
   "Some small enhancements to Prismatic Schema that are valuable to, or needed by, the Swagger support."
   {:added "0.1.27"}
   (:require [schema.core :as s]
-            [schema.macros :as macros]
+            [schema.spec.leaf :as leaf]
             [io.aviso.toolchest.macros :refer [cond-let]]
-            [io.aviso.toolchest.metadata :refer [assoc-meta]]
-            [schema.coerce :as coerce])
+            [io.aviso.toolchest.metadata :refer [assoc-meta]])
   (:import [schema.core Maybe EnumSchema Both OptionalKey]))
 
 (defmacro schema
@@ -40,11 +39,11 @@
 (defrecord IsInstance [^Class expected-class]
   s/Schema
 
-  (walker [this]
-    (fn [x]
-      (if (instance? expected-class x)
-        x
-        (macros/validation-error this x (list 'instance? expected-class x)))))
+  (spec [_]
+    (leaf/leaf-spec
+      (fn [x]
+        (when (instance? expected-class x)
+          x))))
 
   (explain [_]
     (list 'instance? expected-class))


### PR DESCRIPTION
This pull request contains a series of commits upgrading the dependencies of rook and minor patches to the code to handle changes in those dependencies. I originally only wanted to use prismatic/schema 1.0.1 since my project depended on it already but.. I got carried away.

The dependencies upgraded include:

* org.clojure/clojure 1.6.0 to 1.7.0
* ring-middleware-format 0.5.0 to 0.6.0
* medley 0.6.0 to 0.7.0
* speclj 3.2.0 to 3.3.1
* lein-shell 0.4.0 to 0.4.1
* prismatic/schema 0.4.4 to 1.0.1

Of these:

org.clojure/clojure
* Required a change to a test because ordering of maps has changed causing a test to fail.

prismatic/schema 
* The protocol schema.core.Schema has changed, the walker method was removed from the protocol and replaced with a spec method. This protocol is used in io.aviso.rook.schema.IsInstance and had to change. The IsInstance record was validating that the type of a node matched a specific class. In the new system of 'specs' this would seem to be a leaf-spec (since as a java object we will not farther * decompose it) that checks the type of its argument

If any or all of this is of use to rook, consider it yours. If you have no interest in it, feel free to reject the pull request, and I shall not take any offence. 

Thanks for all the hard work on Rook. I appreciate it.