### PR TITLE
Optional custom coercions

### DIFF
--- a/manual/en/validation.ad
+++ b/manual/en/validation.ad
@@ -57,6 +57,44 @@ Schema doesn't have a good way to identify relationships between the keys; for i
 In this simple example, it can be simply ignored, but in other cases, you may need logic inside
 your endpoint function to cross-validate parameter values.
 
+== Custom coercions
+
+Useful when params input needs to be transformed in a custom way prior to using it.
+Primarily useful when dealing with nested parameters, to obtain a vector when keys are present.
+
+[source,clojure]
+----
+(s/defschema IndexParameters
+  {:tags [s/Keyword]
+   s/Any s/Any})
+
+(defn- ->vector [vm]
+  (cond (vector? vm) vm
+        (map? vm) (vals vm)
+        :else []))
+
+(def index-coercions
+  {[s/Keyword] ->vector})
+
+(defn index
+  "Lists out all hotel rooms, filtered by tag."
+  {:schema IndexParameters
+   :coercions index-coercions}
+  [^:injected db-conn
+   {tags :tags
+    :as params}]
+    ...
+  )
+----
+
+With the custom coercions in the example the following two calls will both yield a vector in the tags parameter:
+
+* /foos?tags[]=big&tags[]=small
+* /foos?tags[0]=big&tags[1]=small
+
+Without the custom coercion, the second query string would have yielded a map for the tags parameter, resulting
+in a validation error.
+
 == Body Validation
 
 Validation of the body is essentially the same.  The :body-params request key is validated against the :body-schema

--- a/manual/en/validation.ad
+++ b/manual/en/validation.ad
@@ -70,7 +70,7 @@ Primarily useful when dealing with nested parameters, to obtain a vector when ke
 
 (defn- ->vector [vm]
   (cond (vector? vm) vm
-        (map? vm) (vals vm)
+        (map? vm) (vals vm) ; caution, vals does not preserve order; just an example.
         :else []))
 
 (def index-coercions

--- a/spec/validating.clj
+++ b/spec/validating.clj
@@ -2,6 +2,17 @@
   (:require [schema.core :as s]
             [io.aviso.rook.utils :as utils]))
 
+(defn ->vector [vm]
+  (cond (vector? vm) vm
+        (map? vm) (vals vm)
+        :else []))
+
+(defn index
+  {:schema    {:tags [s/Str]}
+   :coercions {[s/Str] ->vector}}
+  [params]
+  (utils/response 200 (-> params :tags sort)))
+
 (defn create
   {:schema {:name                     s/Str
             (s/optional-key :address) [s/Str]

--- a/spec/validating.clj
+++ b/spec/validating.clj
@@ -4,7 +4,7 @@
 
 (defn ->vector [vm]
   (cond (vector? vm) vm
-        (map? vm) (vals vm)
+        (map? vm) (vals vm) ; caution, vals does not preserve order; works for the purpose of the testing
         :else []))
 
 (defn index


### PR DESCRIPTION
This PR adds an optional `:coercions` metadata key that holds a map containing coercions.
When present, the coercions are merged into the default coercions map. 
Custom coercions can be useful for transforming incoming params.
For more info on usage see the documentation changes in the PR.

#### Rationale

When a key is present, ring's nested-params middleware turns it into a map:

```
?foo[]=1&foo[]=2 => [1 2]
?foo[0]=1&foo[1]=2 => {0 1 1 2}
```

Since the ring/nested-params middleware doesn't do parts matching like rack's nested params, a key is mandatory to match parts:

```
?foo[][x]=1&foo[][y]=2&foo[][x]=3&foo[][y]=4 => 
ring's: [{:x 1} {:y 2} {:x 3} {:y 4}] 
vs rack's: [{:x 1 :y 2} {:x 3 :y 4}]
```

The mandatory key turns the result into maps:

```
?foo[0][x]=1&foo[0][y]=2&foo[1][x]=3&foo[1][y]=4 => {0 {:x 1 :y 2} 1 {:x 3 :y 4}}
```

In this case we only care about the values as a vector.
Schema coercion `map->vector` (via, say, vals) would be helpful in this case.
